### PR TITLE
Remove unneeded z-index

### DIFF
--- a/split-pane.css
+++ b/split-pane.css
@@ -24,7 +24,6 @@ https://raw.github.com/shagstrom/split-pane/master/LICENSE
 	overflow: auto;
 	top: auto;
 	bottom: 0;
-	z-index: 1;
 }
 
 .split-pane.fixed-top > .split-pane-component:first-child,
@@ -42,7 +41,6 @@ https://raw.github.com/shagstrom/split-pane/master/LICENSE
 	left: 0;
 	cursor: ns-resize;
 	cursor: n-resize\9;
-	z-index: 2;
 }
 
 .split-pane.fixed-top > .split-pane-divider > .split-pane-divider-inner,
@@ -66,7 +64,6 @@ https://raw.github.com/shagstrom/split-pane/master/LICENSE
 	overflow: auto;
 	left: auto;
 	right: 0;
-	z-index: 1;
 }
 
 .split-pane.fixed-left > .split-pane-component:first-child,
@@ -84,7 +81,6 @@ https://raw.github.com/shagstrom/split-pane/master/LICENSE
 	top: 0;
 	cursor: ew-resize;
 	cursor: w-resize\9;
-	z-index: 2;
 }
 
 .split-pane.fixed-left > .split-pane-divider > .split-pane-divider-inner,


### PR DESCRIPTION
The `.split-pane-component`, `.split-pane-divider-inner` and `.split-pane-divider` have a `z-index` of `1` or `2`. These values can interfere with the CSS of a project in which this plugin is used, in my case a modal with a `z-index: 1;`.

In my opinion these values are not needed for this plugin to function. It looks like they are there for legacy reasons and are not needed anymore.

@shagstrom would it makes sense to remove them? Or are they needed for a functioning split-pane?
