### PR TITLE
Allow package to depend on jQuery 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,6 @@
   "description": "jQuery Split Pane plugin",
   "license": "MIT",
   "dependencies":{
-    "jquery": "^1.11.1"
+    "jquery": ">=1.11.1 < 3.0.0"
   }
 }


### PR DESCRIPTION
I've tested the package in my environment and it works well with jQuery 2 as well. 
If I download the package with npm, I get a separate copy of npm with the package, that collides with my latest version of jQuery (2.2.4)