### PR TITLE
Filter out resize events if invisible

### DIFF
--- a/split-pane.js
+++ b/split-pane.js
@@ -121,7 +121,7 @@ https://raw.github.com/shagstrom/split-pane/master/LICENSE
 			parent = $splitPane.parent().closest('.split-pane')[0] || window;
 		$(parent).on(parent === window ? 'resize' : 'splitpaneresize', function(event) {
 			var target = event.target === document ? window : event.target;
-			if (target === parent) {
+			if (target === parent && $($splitPane[0]).is(":visible")) {
 				internalHandler(event);
 			}
 		});


### PR DESCRIPTION
When splitPane becomes hidden its offsetWidth and offsetHeight is set to zero. This triggers resize handler. Then it calculates maxFirstComponentWidth as a difference between zero offsetWidth and other values, which produces and passes negative "left" value into setLeft. As a result the whole panel shifts beyond the screen after becoming visible again.